### PR TITLE
Fix: Formatierung bei Datei Export (#25)

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">

--- a/pom.xml
+++ b/pom.xml
@@ -127,5 +127,18 @@
 			<artifactId>poi-ooxml</artifactId>
 			<version>5.2.3</version>
 		</dependency>
+		<dependency>
+			<groupId>com.itextpdf</groupId>
+			<artifactId>itext7-core</artifactId>
+			<version>7.1.15</version>
+			<type>pom</type>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.4.11</version>
+		</dependency>
+
+
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -121,12 +121,6 @@
 			<version>RELEASE</version>
 			<scope>test</scope>
 		</dependency>
-
-		<dependency>
-			<groupId>org.apache.poi</groupId>
-			<artifactId>poi-ooxml</artifactId>
-			<version>5.2.3</version>
-		</dependency>
 		<dependency>
 			<groupId>com.itextpdf</groupId>
 			<artifactId>itext7-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -121,5 +121,11 @@
 			<version>RELEASE</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.poi</groupId>
+			<artifactId>poi-ooxml</artifactId>
+			<version>5.2.3</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/controller/AdminDashboardController.java
+++ b/src/main/java/controller/AdminDashboardController.java
@@ -21,7 +21,9 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 public class AdminDashboardController {
@@ -163,7 +165,6 @@ public class AdminDashboardController {
             });
         }
     }
-
     @FXML
     private void exportCSV() {
         FileChooser chooser = new FileChooser();
@@ -173,24 +174,27 @@ public class AdminDashboardController {
         if (file == null) return;
 
         try (FileWriter w = new FileWriter(file)) {
-            w.write("Email,Date,Invoice Amount,Reimbursement,Classification,Status\n");
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+            w.write("\"Email\";\"Date\";\"Invoice Amount\";\"Reimbursement\";\"Classification\";\"Status\"\n");
+
             for (Invoice inv : invoiceTable.getItems()) {
-                w.write(String.join(",",
-                        inv.getEmail(),
-                        inv.getSubmissionDate().toString(),
-                        String.valueOf(inv.getInvoiceAmount()),
-                        String.valueOf(inv.getReimbursementAmount()),
-                        inv.getCategory().toString(),
-                        inv.getStatus().toString()
+                w.write(String.join(";",
+                        "\"" + inv.getEmail() + "\"",
+                        "\"" + inv.getSubmissionDate().format(formatter) + "\"",
+                        "\"" + String.format("%.2f", inv.getInvoiceAmount()).replace(".", ",") + "\"",
+                        "\"" + String.format("%.2f", inv.getReimbursementAmount()).replace(".", ",") + "\"",
+                        "\"" + inv.getCategory().toString() + "\"",
+                        "\"" + inv.getStatus().toString() + "\""
                 ) + "\n");
             }
+
             messageLabel.setText("Exported CSV successfully.");
         } catch (IOException e) {
             e.printStackTrace();
             messageLabel.setText("Error exporting CSV.");
         }
     }
-
     @FXML
     private void exportPayrollJSON() {
         FileChooser chooser = new FileChooser();

--- a/src/main/resources/view/AdminDashboardView.fxml
+++ b/src/main/resources/view/AdminDashboardView.fxml
@@ -50,6 +50,7 @@
                 <Button text="Delete Invoice" fx:id="deleteButton" onAction="#deleteInvoice" styleClass="main-button"/>
                 <Button text="Reject Invoice" fx:id="rejectButton" onAction="#rejectInvoice" styleClass="main-button"/>
                 <Button text="Export CSV" fx:id="exportCSVButton" onAction="#exportCSV" styleClass="main-button"/>
+                <Button fx:id="exportPdfButton" text="Export PDF" onAction="#exportPayrollPDF"  styleClass="main-button"/>
                 <Button text="Export Payroll JSON" onAction="#exportPayrollJSON" styleClass="main-button"/>
                 <Button text="Export Payroll XML" onAction="#exportPayrollXML" styleClass="main-button"/>
                 <Button text="Edit Invoice" fx:id="editButton" onAction="#editInvoice" styleClass="main-button"/>


### PR DESCRIPTION
Diese Änderungen beheben das Problem mit der Formatierung beim Datei-Export:

- CSV-Export:
  - Formatierung bei Export, die Daten werden in eine Tabelle jetzt formatiert/eingefügt

- PDF-Export:
  - Strukturierte Tabelle
  - Fett formatierte Spaltenüberschriften

-JSON und XML-Export
 - Die exportierten Daten beinalten  jetzt  nicht nur alle Benutzer, sondern auch die Summe aller 
Rechnungen pro Monat wie in Anforderungen Lunchify steht.

Fixes #25
